### PR TITLE
add YAML-formatted spec; build with sphinx-jsonschema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs/_build

--- a/demes-specification.yaml
+++ b/demes-specification.yaml
@@ -1,0 +1,404 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: Demes graph
+description: |
+  A ``demes`` model is a graph in which each deme is a vertex, and graph edges
+  indicate ancestor/descendant relationships. Additional relationships between
+  demes are described using `pulses` for instantaneous migrations, and
+  `migrations` for continuous migration over a time interval.
+type: object
+
+properties:
+  description:
+    description: A concise description of the demographic model.
+    type: string
+    examples:
+      - An island stepping stone model with 5 demes.
+      - |
+        The Example et al. (3140) model of Tringuul expansion out of the
+        Interrezella Nebula. Includes successive bottlenecks associated with
+        colonisations throughout the system.
+  doi:
+    description: |
+      The DOI(s) of the publication(s) in which the model was inferred or
+      originally described.
+    type: array
+    items:
+      type: string
+    default: []
+
+  time_units:
+    description: The units of time used to specify times and time intervals.
+    type: string
+    examples:
+    - generations
+    - years
+
+  generation_time:
+    description: |
+      The number by which times must be divided, to convert them to have
+      units of generations. Unless ``time_units`` are ``generations``,
+      the ``generation_time`` must be specified.
+    type: number
+    exclusiveMinimum: 0
+    exclusiveMaximum: .inf
+    examples:
+    - 1
+    - 29.5
+    default: null
+
+  demes:
+    description: A list of demes in the demographic model.
+    type: array
+    minItems: 1
+    items:
+      $ref: '#/definitions/deme'
+
+  pulses:
+    description: A list of *instantaneous* pulses of migration between demes.
+    type: array
+    items:
+      $ref: '#/definitions/pulse'
+    default: []
+
+  migrations:
+    description: |
+      Migrations occurring *continuously* over a time interval.
+      Continuous migrations may be symmetric, or asymmetric.
+    type: object
+    properties:
+      symmetric:
+        description: |
+          A list of continuous migrations occuring symmetrically among
+          a set of demes. Symmetric migrations offer a convenient shorthand,
+          that would be more cumbersome to define using asymmetric migrations.
+        type: array
+        items:
+          $ref: '#/definitions/symmetric_migration'
+        default: []
+      asymmetric:
+        description: |
+          A list of continuous migrations occuring unidirectionally from
+          a source deme to a destination deme.
+        type: array
+        items:
+          $ref: '#/definitions/asymmetric_migration'
+        default: []
+
+required:
+- description
+- time_units
+- demes
+
+definitions:
+  id:
+    description: |
+      A unique string identifier for a deme.
+      Must be a valid `python identifier
+      <https://docs.python.org/3/reference/lexical_analysis.html#identifiers>`_.
+    type: string
+    examples:
+    - deme1
+    - pop_2
+    - YRI
+
+  rate:
+    description: A rate for migrations, selfing, or cloning.
+    type: number
+    minimum: 0
+    maximum: 1
+    examples:
+    - 0.1
+    - 1e-5
+
+  proportion:
+    description: An ancestry proportion.
+    type: number
+    exclusiveMinimum: 0
+    maximum: 1
+    examples:
+    - 0.1
+    - 1e-5
+
+  size:
+    target:
+    - "#/definitions/size"
+    description: The population size of a deme.
+    type: number
+    exclusiveMinimum: 0
+    exclusiveMaximum: .inf
+    examples:
+    - 100
+    - 1e5
+
+  start_time:
+    description: The oldest time of a time interval (numerical upper bound).
+    type: number
+    exclusiveMinimum: 0
+    maximum: .inf
+    examples:
+    - .inf
+    - 1e6
+    - 20000
+
+  end_time:
+    description: The youngest time of a time interval (numerical lower bound).
+    type: number
+    minimum: 0
+    exclusiveMaximum: .inf
+    examples:
+    - 1e6
+    - 20000
+    - 0
+
+  epoch:
+    description: A deme-specific period of time spanning the half-open interval
+     ``(start_time, end_time]``, in which a fixed set of population parameters
+     apply.
+    type: object
+    properties:
+      start_time:
+        description: |
+          The most ancient time of the epoch, in ``time_units`` before the present.
+        $ref: '#/definitions/start_time'
+      end_time:
+        description: |
+          The most recent time of the epoch, in ``time_units`` before the present.
+        $ref: '#/definitions/end_time'
+      initial_size:
+        description: The population size at the epoch's ``start_time``.
+        $ref: '#/definitions/size'
+      final_size:
+        description: The population size at the epoch's ``end_time``.
+        $ref: '#/definitions/size'
+      size_function:
+        description: |
+          A function describing the population size change between
+          ``start_time`` and ``end_time``.
+        type: string
+        examples:
+        - constant
+        - exponential
+      cloning_rate:
+        $ref: '#/definitions/rate'
+      selfing_rate:
+        $ref: '#/definitions/rate'
+
+  deme:
+    description: |
+      A collection of individuals that are exchangeable at any fixed time.
+      The deme may be a descendant of one or more demes in the graph, and may
+      be an ancestor to others. The deme exists over the half-open time interval
+      ``(start_time, end_time]``, and it may continue to exist after
+      contributing ancestry to a descendant deme.
+    type: object
+    properties:
+      id:
+        description: |
+          An identifier for this deme. Must be unique among all demes in the
+          graph.
+        $ref: '#/definitions/id'
+      description:
+        description: A concise description of the deme.
+        type: string
+        default: null
+      ancestors:
+        description: |
+          The ancestors of the deme at the start of the deme's first epoch.
+          May be omitted if the deme has no ancestors in the graph.
+          If two or more ancestors are specified, the ``proportions``
+          must also be specified, and the ``start_time`` must be defined
+          (either specified directly, or indirectly in the deme's first epoch).
+          Each ancestor must be in the graph, and each ancestor must be
+          specified only once. A deme must not be one of its own ancestors.
+        type: array
+        items:
+          $ref: '#/definitions/id'
+        default: []
+      proportions:
+        description: |
+          The proportions of ancestry derived from each of the ``ancestors``
+          at the start of the deme's first epoch.
+          The ``proportions`` may be omitted if there are no ancestors, or if
+          there is only one ancestor.
+          The ``proportions`` must be ordered to correspond with the
+          order of ``ancestors``. The proportions must sum to 1 (within a
+          reasonable tolerance, e.g. 1e-9).
+        type: array
+        items:
+          $ref: '#/definitions/proportion'
+      initial_size:
+        description: The population size at the deme's ``start_time``.
+        $ref: '#/definitions/size'
+      final_size:
+        description: The population size at the deme's ``end_time``.
+        $ref: '#/definitions/size'
+      start_time:
+        description: |
+          The most ancient time at which the deme exists, in ``time_units``
+          before the present.
+          The ``start_time`` must correspond with the interval of existence
+          for each of the deme's ``ancestors``. I.e. the ``start_time`` must
+          be within the half-open interval ``(deme.start_time, deme.end_time]``
+          for each deme in ``ancestors``.
+          If ``start_time`` is specified, and the deme's first epoch's
+          ``start_time`` is also specified, they must have the same value.
+
+          If not specified, the deme's ``start_time`` shall be obtained
+          according to the following rules (the first matching rule shall
+          be used).
+
+           - If the first epoch's ``start_time`` is specified, its value
+             shall be used.
+           - If the deme has one ancestor, and the ancestor has an
+             ``end_time > 0``, the ancestor's ``end_time`` value shall be
+             used. 
+           - If the deme has no ancestors, the ``start_time`` shall be
+             infinitely far into the past. I.e. the ``start_time`` shall
+             have the value ``infinity``.
+
+          If the ``start_time`` has not been defined after following the
+          rules above, an error shall be raised. E.g. an error shall be
+          raised for the following conditions.
+
+           - If the deme has multiple ancestors,
+             and neither the deme's ``start_time`` nor the first epoch's
+             ``start_time`` is specified.
+           - If the deme has one ancestor with an ``end_time == 0``,
+             and neither the deme's ``start_time`` nor the first epoch's
+             start time is specified.
+
+        $ref: '#/definitions/start_time'
+      end_time:
+        description: |
+          The most recent time at which the deme exists, in ``time_units``
+          before the present.
+          If ``end_time`` is specified, and the deme's last epoch's
+          ``end_time`` is also specified, they must have the same value.
+
+          If not specified, the deme's ``end_time`` shall be obtained
+          according to the following rules (the first matching rule shall
+          be used).
+
+           - If the last epoch's ``end_time`` is specified, its value
+             shall be used.
+           - The ``end_time`` shall be the present. I.e. the ``end_time``
+             shall have the value ``0``.
+        $ref: '#/definitions/end_time'
+      epochs:
+        description: |
+          The list of epochs applying to the deme. If not specified,
+          a single epoch shall be constructed from the deme's ``start_time``,
+          ``end_time``, ``initial_size``, and ``final_size`` properties.
+        type: array
+        minItems: 1
+        items:
+          $ref: '#/definitions/epoch'
+    required:
+    - id
+
+  pulse:
+    description: |
+      An instantaneous pulse of migration at ``time``, from the ``source`` deme
+      into the ``dest`` deme.
+    type: object
+    properties:
+      source:
+        description: The deme ID of the migration source.
+        $ref: '#/definitions/id'
+      dest:
+        description: The deme ID of the migration destination.
+        $ref: '#/definitions/id'
+      time:
+        description: |
+          The time of migration, in ``time_units`` before the present.
+          The ``source`` and ``dest`` demes must both exist at the given
+          ``time``.  I.e. ``time`` must be contained in the
+          ``(deme.start_time, deme.end_time]`` interval of the ``source``
+          deme and the ``dest`` deme.
+        type: number
+        exclusiveMinimum: 0
+        exclusiveMaximum: .inf
+      proportion:
+        description: |
+          The proportion of the ``source`` deme's ancestry in the ``dest`` deme
+          immediately after the ``time`` of migration.
+        $ref: '#/definitions/proportion'
+    required:
+    - source
+    - dest
+    - time
+    - proportion
+
+  asymmetric_migration:
+    description: |
+      Continuous migration from the ``source`` deme to the ``dest`` deme,
+      over an the half-open time interval ``(start_time, end_time]``.
+    type: object
+    properties:
+      source:
+        description: The deme ID of the migration source.
+        $ref: '#/definitions/id'
+      dest:
+        description: The deme ID of the migration destination.
+        $ref: '#/definitions/id'
+      start_time:
+        description: |
+          The time at which migration begins, in ``time_units`` before the present.
+          The ``start_time`` must be contained in the
+          ``[deme.start_time, deme.end_time)`` interval of the ``source`` deme
+          and the ``dest`` deme.
+          If not specified, the migration ``start_time`` shall be the minimum
+          ``deme.start_time`` of the ``source`` deme and the ``dest`` deme.
+        $ref: '#/definitions/start_time'
+      end_time:
+        description: |
+          The time at which migration stops, in ``time_units`` before the present.
+          The ``end_time`` must be contained in the
+          ``(deme.start_time, deme.end_time]`` interval of the ``source`` deme
+          and the ``dest`` deme.
+          If not specified, the migration ``end_time`` shall be the maximum
+          ``deme.end_time`` of the ``source`` deme and the ``dest`` deme.
+        $ref: '#/definitions/end_time'
+      rate:
+        description: The rate of migration per generation.
+        $ref: '#/definitions/rate'
+    required:
+    - source
+    - dest
+    - rate
+
+  symmetric_migration:
+    description: |
+      Continuous migration among a set of demes over the half-open time
+      interval ``(start_time, end_time]``.
+    type: object
+    properties:
+      demes:
+        description: The deme IDs of the migrating demes.
+        type: array
+        items:
+          $ref: '#/definitions/id'
+        minItems: 2
+      start_time:
+        description: |
+          The time at which migration begins, in ``time_units`` before the present.
+          The ``start_time`` must be contained in the
+          ``[deme.start_time, deme.end_time)`` interval of every deme in ``demes``.
+          If not specified, the migration ``start_time`` shall be the minimum
+          ``deme.start_time`` over the demes in ``demes``.
+        $ref: '#/definitions/start_time'
+      end_time:
+        description: |
+          The time at which migration stops, in ``time_units`` before the present.
+          The ``end_time`` must be contained in the
+          ``(deme.start_time, deme.end_time]`` interval of every deme in ``demes``.
+          If not specified, the migration ``end_time`` shall be the maximum
+          ``deme.end_time`` over the demes in ``demes``.
+        $ref: '#/definitions/end_time'
+      rate:
+        description: The rate of migration per generation.
+        $ref: '#/definitions/rate'
+    required:
+    - demes
+    - rate
+

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,14 @@
+SPHINXOPTS    = -W
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+html:
+	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: html Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,17 @@
+/*
+ * RTD adds horizontal scrollbars to tables, making the tables very difficult
+ * to read. The workaround here will wrap lines within table cells.
+ * https://github.com/readthedocs/sphinx_rtd_theme/issues/117
+ */
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      /* !important prevents the common CSS stylesheets from overriding
+         this as on RTD they are loaded after this stylesheet */
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      overflow: visible !important;
+   }
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,63 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+
+
+# -- Project information -----------------------------------------------------
+
+project = "demes-spec"
+copyright = "2020, PopSim Consortium"
+author = "PopSim Consortium"
+
+# The version info for the project you're documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+version = release = "alpha"
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.todo",
+    "sphinx-jsonschema",
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# If true, `todo` and `todoList` produce output, else they produce nothing.
+todo_include_todos = True
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]
+
+def setup(app):
+    # CSS workaround for sphinx_rtd_theme scrollbar/table bug.
+    app.add_stylesheet("custom.css")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,22 @@
+.. demes documentation master file, created by
+   sphinx-quickstart on Sun Jul 19 16:51:55 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to the Demes Specification!
+===================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   introduction
+   spec
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,0 +1,7 @@
+============
+Introduction
+============
+
+.. todo::
+
+   Write this.

--- a/docs/spec.rst
+++ b/docs/spec.rst
@@ -1,0 +1,34 @@
+=============
+Specification
+=============
+
+The structure of ``demes``' data model is formally defined using
+`JSON schema <https://json-schema.org/>`_ and rendered below as a table.
+A machine readable version of the schema (from which this table was generated)
+can be found in the ``demes-specification.yaml`` file of the 
+`demes-spec repository <https://github.com/popsim-consortium/demes-spec>`_.
+
+.. note::
+
+ The formal requirements of ``demes``' data model impose inter-property
+ constraints that cannot be described using JSON schema alone.
+ These additional conditions are described throughout this document
+ using the language *must* or *must not*.
+
+For each object defined below, the strictly required properties are indicated
+in **bold**, and these properties must be specified by the user.
+The remaining properties, which may be omitted by the user, must nevertheless
+have defined values. Where default values are obtained from other properties,
+this is described in the ``description`` field, using the language *shall*
+or *shall not*.
+
+Software implementing this specification is expected to raise errors
+when processing input for which the formal requirements are not met.
+
+.. jsonschema:: ../demes-specification.yaml
+   :lift_description:
+   :lift_definitions:
+   :auto_target:
+   :auto_reference:
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+sphinx-jsonschema==1.16.6
+sphinx==3.3.1
+sphinx_rtd_theme==0.5.0


### PR DESCRIPTION
I converted the JSON schema file from https://github.com/popsim-consortium/demes-python/blob/main/schema/graph.json to a YAML file, added a bunch of `description` fields, and pulled in `sphinx-jsonschema` to render it to HTML (this permits RST in the description fields!). We might want to monkey patch a few things in `sphinx-jsonschema` to alter the formatting/layout. There might be some differences in the spec wrt. the current demes-python behaviour, and certainly there are some omissions (e.g. the epoch properties need descriptions of where defaults come from), but I think this a reasonable start.