### PR TITLE
Update docs github action.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,10 +12,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-            ref: ${{github.event.pull_request.head.ref}}
-            repository: ${{github.event.pull_request.head.repo.full_name}}
-
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
@@ -27,21 +23,15 @@ jobs:
         run: make -C docs
 
       - name: Checkout docs site
+        if: github.event.push
         uses: actions/checkout@v2
         with:
           repository: popsim-consortium/demes-spec-docs
           token: ${{ secrets.POPSIMBOT_DEMES_SPEC_DOCS_TOKEN }}
           path: demes-spec-docs
 
-      - name: Copy our docs to the PR specific location
-        if: github.event.pull_request
-        run: |
-          cd demes-spec-docs
-          rm -rf ${{github.event.pull_request.number}}
-          cp -r ../docs/_build/html ${{github.event.pull_request.number}}
-
       - name: Copy our docs to the tag specific location
-        if: (!github.event.pull_request)
+        if: github.event.push
         run: |
           cd demes-spec-docs
           export DEST=`echo ${GITHUB_REF} | sed -e "s/refs\/heads\///g" |  sed -e "s/refs\/tags\///g"`
@@ -49,19 +39,11 @@ jobs:
           cp -r ../docs/_build/html $DEST
 
       - name: Commit and push the docs
+        if: github.event.push
         run: |
           cd demes-spec-docs
           git config user.name PopSim-bot
           git config user.email graham.gower+popsim-bot@gmail.com
           git add .
-          git diff-index --quiet HEAD || git commit -m "Automated doc build for ${{github.event.pull_request.number}} ${GITHUB_REF}"
+          git diff-index --quiet HEAD || git commit -m "Automated doc build for ${GITHUB_REF}"
           git push
-
-      - name: Comment on PR
-        if: github.event.pull_request
-        uses: mshick/add-pr-comment@v1
-        with:
-          message: |
-            📖 Docs for this PR can be previewed [here](https://popsim-consortium.github.io/demes-spec-docs/${{github.event.pull_request.number}}/)
-          allow-repeats: false
-          repo-token: ${{ secrets.POPSIMBOT_DEMES_SPEC_DOCS_TOKEN }}


### PR DESCRIPTION
This removes the docs preview for pull requests in favour
of just building the docs. When a pull request is merged,
a "push" is triggered and so the docs will still be committed
to the docs repository.

The docs preview relied on a feature which turned out to be
a security risk (which is why it was previously disabled).
No simple alternative is available, so this won't be reenabled.