### PR TITLE
Change description of pulse time to match implementation.

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -360,9 +360,9 @@ The deme name of the migration destination.
 The time of migration, in
 in {ref}`sec_spec_mdm_time_units` before the present.
 The demes defined by ``sources`` and ``dest`` must both exist at the given
-``time``.  I.e. ``time`` must be contained in the
-``(deme.start_time, deme.end_time]`` interval of the ``sources``
-demes and the ``dest`` deme.
+``time``. 
+The pulse time must be in `(start_time, end_time]` with respect to each deme in `sources`
+and in `[start_time, end_time)` with respect to `dest`.
 
 #### proportions
 The proportions of ancestry in the ``dest`` deme derived from the demes


### PR DESCRIPTION
This PR changes the description of pulse times to reflect the actual behavior.

The following code demonstrates the behavior:

```python
import demes

bad_pulse_time_0 = """
description: invalid b/c pulse time is start time of deme 1
time_units: generations
demes:
 - name: ancestor
   epochs:
    - start_size: 1000
      end_time: 100
 - name: der1
   ancestors: [ancestor]
   start_time: 100
   epochs:
    - start_size: 1000
 - name: der2
   ancestors: [ancestor]
   start_time: 500
   epochs:
    - start_size: 1000
pulses:
 - sources: [der1]
   dest: der2
   time: 100
   proportions: [0.5]
"""

bad_pulse_time_1 = """
description: invalid because there WILL NOT be adults in der2 at the next tick of the clock
time_units: generations
demes:
 - name: ancestor
   epochs:
    - start_size: 1000
      end_time: 100
 - name: der1
   ancestors: [ancestor]
   start_time: 100
   epochs:
    - start_size: 1000
 - name: der2
   ancestors: [ancestor]
   start_time: 500
   epochs:
    - start_size: 1000
      end_time: 50
pulses:
 - sources: [der1]
   dest: der2
   time: 50
   proportions: [0.5]
"""

for model in [bad_pulse_time_0, bad_pulse_time_1]:
    try:
        _ = demes.loads(model)
        raise RuntimeError("expected exception")
    except ValueError:
        pass

ok_pulse_time_0 = """
description: okay b/c there are adults in der1 and there WILL be in der2
time_units: generations
demes:
 - name: ancestor
   epochs:
    - start_size: 1000
      end_time: 100
 - name: der1
   ancestors: [ancestor]
   start_time: 101
   epochs:
    - start_size: 1000
 - name: der2
   ancestors: [ancestor]
   start_time: 100
   epochs:
    - start_size: 1000
pulses:
 - sources: [der1]
   dest: der2
   time: 100
   proportions: [0.5]
"""

ok_pulse_time_1 = """
description: okay because the pulse time is the LAST time that there will be 
 adults in der1 and der2 still exists
time_units: generations
demes:
 - name: ancestor
   epochs:
    - start_size: 1000
      end_time: 100
 - name: der1
   ancestors: [ancestor]
   start_time: 100
   epochs:
    - start_size: 1000
      end_time: 50
 - name: der2
   ancestors: [ancestor]
   start_time: 500
   epochs:
    - start_size: 1000
pulses:
 - sources: [der1]
   dest: der2
   time: 50
   proportions: [0.5]
"""

for model in [ok_pulse_time_0, ok_pulse_time_1]:
    _ = demes.loads(model)
```

I noticed this error in the spec docs when looking at tskit-dev/msprime#2353
